### PR TITLE
fix: remove tx hash length constraint

### DIFF
--- a/app/mcp.ts
+++ b/app/mcp.ts
@@ -841,7 +841,6 @@ export const mcpHandler = initializeMcpApiHandler(
             calldata: z.string().optional().describe("Raw calldata to decode"),
             tx: z
               .string()
-              .length(66)
               .optional()
               .describe("Transaction hash or explorer URL"),
           })


### PR DESCRIPTION
I missed the fact that decode calldata also accepted tx url from blockexplorers