### PR TITLE
fix: invalid Tailwind class usage for text color

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -176,7 +176,7 @@
                   Once configured, your Cursor IDE will automatically connect to
                   the MCP SSE server. You can verify the connection by opening
                   Composer in Agent Mode (<code
-                    class="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-[#FBFAF9]-600 dark:text-[#FBFAF9]-400"
+                    class="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-[#FBFAF9] dark:text-[#FBFAF9]"
                     >Cmd + I</code
                   >) and asking it "What is the balance of this wallet
                   address?". You should see a card like so in the Agent sidebar


### PR DESCRIPTION
noticed an invalid Tailwind class being used: `text-[#FBFAF9]-600`.

> Tailwind doesn’t support combining custom hex colors with modifiers like `-600`.

replaced it with the correct usage to ensure proper styling and avoid build issues.
