### PR TITLE
fix typo in shortName for deprecated-calypso-testnet

### DIFF
--- a/app/commons/_chains.ts
+++ b/app/commons/_chains.ts
@@ -50268,7 +50268,7 @@ export const _chains = [
       decimals: 18,
     },
     infoURL: "https://calypsohub.network/",
-    shortName: "deprected-calypso-testnet",
+    shortName: "deprecated-calypso-testnet",
     chainId: 344106930,
     networkId: 344106930,
     slip44: 1,


### PR DESCRIPTION


**Description:**  
Corrected `deprected` → `deprecated`