### PR TITLE
Updated the protocol Search logic

### DIFF
--- a/lib/protocols.ts
+++ b/lib/protocols.ts
@@ -138,12 +138,10 @@ class ProtocolDatabase {
         return false
       if (
         contract &&
-        !protocol.contract.toLowerCase().includes(contract.toLowerCase())
-      )
-        return false
-      if (
-        contract &&
-        !protocol.address.toLowerCase().includes(contract.toLowerCase())
+        !(
+          protocol.contract.toLowerCase().includes(contract.toLowerCase()) ||
+          protocol.address.toLowerCase().includes(contract.toLowerCase())
+        )
       )
         return false
       return true


### PR DESCRIPTION
Updated the protocol search logic so that a user-supplied contract query now matches either the protocol’s contract name or its address, instead of requiring both fields to include the query

Testing
`REDIS_URL=redis://localhost:6379 pnpm build`

**Key Points for Improvement**

- Add automated tests for protocolDb.search to catch edge cases and future regressions in filtering behavior.
- Gracefully handle missing or unavailable Redis instances to avoid repeated connection errors during builds or development.
- Introduce linting or formatting scripts (e.g., pnpm lint) to standardize code style and catch issues earlier in the workflow.